### PR TITLE
Refine IsContainFields function

### DIFF
--- a/include/http.h
+++ b/include/http.h
@@ -25,7 +25,7 @@ private:
 	static const std::vector<std::string> passwdFields;
 	static const std::vector<std::string> sessionFields;
 
-	bool IsContainFields(std::string content, std::vector<std::string> fields);
+	static bool IsContainFields(const std::string &content, const std::vector<std::string> &fields);
 
 	std::string method_;
 	std::string path_;

--- a/src/http.cc
+++ b/src/http.cc
@@ -45,11 +45,11 @@ bool Http::IsCredz()
 		IsContainFields(cookie_, sessionFields);
 }
 
-bool Http::IsContainFields(string content, vector<string> fields)
+bool Http::IsContainFields(const string &content, const vector<string> &fields)
 {
-	boost::algorithm::to_lower(content);
-	for (auto &field : fields) {
-		if (string::npos != content.find(field)) {
+	auto lower_content = boost::to_lower_copy<string>(content);
+	for (const auto &field : fields) {
+		if (string::npos != lower_content.find(field)) {
 			return true;
 		}
 	}


### PR DESCRIPTION
    - Avoid copying fields.
    - Pass the content by const referenceas to handle const
      string parameter. Copy it in the function by to_lower_copy.
    - Declare as a static member function to avoid passing 'this' pointer.

Signed-off-by: Tingyu Huang <soytingyuhuang@gmail.com>